### PR TITLE
Add mouse side button detection for Wayland.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please keep one empty line before and after all headers. (This is required for `
 And please only add new entries to the top of this list, right below the `# Unreleased` header.
 
 # Unreleased
+- Add mouse side button detection for Wayland.
 
 # 0.28.6
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1079,6 +1079,8 @@ pub enum MouseButton {
     Left,
     Right,
     Middle,
+    Back,
+    Forward,
     Other(u16),
 }
 

--- a/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
@@ -22,6 +22,10 @@ use super::{PointerData, WinitPointer};
 const BTN_LEFT: u32 = 0x110;
 const BTN_RIGHT: u32 = 0x111;
 const BTN_MIDDLE: u32 = 0x112;
+/// The fourth non-scroll button, which is often used as "back" in web browsers.
+const BTN_SIDE: u32 = 0x113;
+/// The fifth non-scroll button, which is often used as "forward" in web browsers.
+const BTN_EXTRA: u32 = 0x114;
 
 #[inline]
 pub(super) fn handle_pointer(
@@ -171,6 +175,8 @@ pub(super) fn handle_pointer(
                 BTN_LEFT => MouseButton::Left,
                 BTN_RIGHT => MouseButton::Right,
                 BTN_MIDDLE => MouseButton::Middle,
+                BTN_SIDE => MouseButton::Back,
+                BTN_EXTRA => MouseButton::Forward,
                 button => MouseButton::Other(button as u16),
             };
 


### PR DESCRIPTION
This PR adds support for mouse side button detection for Wayland.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
