### PR TITLE
Add support for wayland resizes (requires fork of sctk and sctk-adwaita)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ features = [
 libc = "0.2.64"
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 percent-encoding = { version = "2.0", optional = true }
-sctk = { package = "smithay-client-toolkit", version = "0.16.0", default_features = false, features = ["calloop"],  optional = true }
-sctk-adwaita = { version = "0.5.1", default_features = false, optional = true }
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/pop-os/client-toolkit", branch = "wayland-resize", default_features = false, features = ["calloop"],  optional = true }
+sctk-adwaita = { git = "https://github.com/pop-os/sctk-adwaita", branch = "wayland-resize", default_features = false, optional = true }
 wayland-client = { version = "0.29.5", default_features = false,  features = ["use_system_lib"], optional = true }
 wayland-protocols = { version = "0.29.5", features = [ "staging_protocols"], optional = true }
 wayland-commons = { version = "0.29.5", optional = true }

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -12,6 +12,7 @@ use sctk::reexports::protocols::unstable::relative_pointer::v1::client::zwp_rela
 use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_pointer_constraints_v1::{ZwpPointerConstraintsV1, Lifetime};
 use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_confined_pointer_v1::ZwpConfinedPointerV1;
 use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_locked_pointer_v1::ZwpLockedPointerV1;
+use sctk::reexports::protocols::xdg_shell::client::xdg_toplevel::ResizeEdge;
 
 use sctk::seat::pointer::{ThemeManager, ThemedPointer};
 use sctk::window::Window;
@@ -19,7 +20,7 @@ use sctk::window::Window;
 use crate::event::ModifiersState;
 use crate::platform_impl::wayland::event_loop::WinitState;
 use crate::platform_impl::wayland::window::WinitFrame;
-use crate::window::CursorIcon;
+use crate::window::{CursorIcon, ResizeDirection};
 
 mod data;
 mod handlers;
@@ -212,6 +213,21 @@ impl WinitPointer {
         // WlPointer::setart_interactive_move() expects the last serial of *any*
         // pointer event (compare to set_cursor()).
         window.start_interactive_move(&self.seat, self.latest_serial.get());
+    }
+
+    pub fn drag_resize_window(&self, window: &Window<WinitFrame>, direction: ResizeDirection) {
+        // WlPointer::setart_interactive_resize() expects the last serial of *any*
+        // pointer event (compare to set_cursor()).
+        window.start_interactive_resize(&self.seat, self.latest_serial.get(), match direction {
+            ResizeDirection::East => ResizeEdge::Right,
+            ResizeDirection::North => ResizeEdge::Top,
+            ResizeDirection::NorthEast => ResizeEdge::TopRight,
+            ResizeDirection::NorthWest => ResizeEdge::TopLeft,
+            ResizeDirection::South => ResizeEdge::Bottom,
+            ResizeDirection::SouthEast => ResizeEdge::BottomRight,
+            ResizeDirection::SouthWest => ResizeEdge::BottomLeft,
+            ResizeDirection::West => ResizeEdge::Left,
+        });
     }
 }
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -606,8 +606,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
+        self.send_request(WindowRequest::DragResizeWindow(direction));
+
+        Ok(())
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/shim.rs
+++ b/src/platform_impl/linux/wayland/window/shim.rs
@@ -23,7 +23,7 @@ use crate::platform_impl::wayland::protocols::wp_fractional_scale_v1::WpFraction
 use crate::platform_impl::wayland::seat::pointer::WinitPointer;
 use crate::platform_impl::wayland::seat::text_input::TextInputHandler;
 use crate::platform_impl::wayland::WindowId;
-use crate::window::{CursorGrabMode, CursorIcon, ImePurpose, Theme, UserAttentionType};
+use crate::window::{CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType};
 
 use super::WinitFrame;
 
@@ -52,6 +52,9 @@ pub enum WindowRequest {
 
     /// Drag window.
     DragWindow,
+
+    /// Drag and resize window.
+    DragResizeWindow(ResizeDirection),
 
     /// Maximize the window.
     Maximize(bool),
@@ -463,6 +466,12 @@ impl WindowHandle {
             pointer.drag_window(&self.window);
         }
     }
+
+    pub fn drag_resize_window(&self, direction: ResizeDirection) {
+        for pointer in self.pointers.iter() {
+            pointer.drag_resize_window(&self.window, direction);
+        }
+    }
 }
 
 #[inline]
@@ -508,6 +517,9 @@ pub fn handle_window_requests(winit_state: &mut WinitState) {
                 }
                 WindowRequest::DragWindow => {
                     window_handle.drag_window();
+                }
+                WindowRequest::DragResizeWindow(direction) => {
+                    window_handle.drag_resize_window(direction);
                 }
                 WindowRequest::Maximize(maximize) => {
                     if maximize {


### PR DESCRIPTION
This allows wayland windows to be resized when client side decorations are used. Although the functionality already exists in later winit versions, due to the difficulty in updating iced to winit 0.29.2 where this was first introduced, I have instead added the functionality to this older version of winit, including minor patches to the versions of sctk and sctk-adwaita used by this older winit.