### PR TITLE
On Orbital, implement `KeyEventExtModifiersSupplement`

### DIFF
--- a/src/platform/modifier_supplement.rs
+++ b/src/platform/modifier_supplement.rs
@@ -1,4 +1,10 @@
-#![cfg(any(windows_platform, macos_platform, x11_platform, wayland_platform))]
+#![cfg(any(
+    windows_platform,
+    macos_platform,
+    x11_platform,
+    wayland_platform,
+    orbital_platform
+))]
 
 use crate::keyboard::Key;
 

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -4,7 +4,12 @@ use std::fmt::{self, Display, Formatter};
 use std::str;
 use std::sync::Arc;
 
-use crate::dpi::{PhysicalPosition, PhysicalSize};
+use smol_str::SmolStr;
+
+use crate::{
+    dpi::{PhysicalPosition, PhysicalSize},
+    keyboard::Key,
+};
 
 pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
 mod event_loop;
@@ -259,5 +264,8 @@ impl VideoMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct KeyEventExtra {}
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct KeyEventExtra {
+    pub key_without_modifiers: Key,
+    pub text_with_all_modifiers: Option<SmolStr>,
+}


### PR DESCRIPTION
This also fixes `logical_key` and `text` not reported in `KeyEvent`.

Rebase of upsteam https://github.com/rust-windowing/winit/pull/3461