### PR TITLE
On Orbital, implement various Window methods

### DIFF
--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -8,8 +8,8 @@ use std::{
 };
 
 use orbclient::{
-    ButtonEvent, EventOption, FocusEvent, HoverEvent, KeyEvent, MouseEvent, MoveEvent, QuitEvent,
-    ResizeEvent, ScrollEvent, TextInputEvent,
+    ButtonEvent, EventOption, FocusEvent, HoverEvent, KeyEvent, MouseEvent, MouseRelativeEvent,
+    MoveEvent, QuitEvent, ResizeEvent, ScrollEvent, TextInputEvent,
 };
 use smol_str::SmolStr;
 
@@ -457,6 +457,14 @@ impl<T: 'static> EventLoop<T> {
                     },
                 });
             }
+            EventOption::MouseRelative(MouseRelativeEvent { dx, dy }) => {
+                event_handler(event::Event::DeviceEvent {
+                    device_id: event::DeviceId(DeviceId),
+                    event: event::DeviceEvent::MouseMotion {
+                        delta: (dx as f64, dy as f64),
+                    },
+                });
+            }
             EventOption::Button(ButtonEvent {
                 left,
                 middle,
@@ -510,7 +518,7 @@ impl<T: 'static> EventLoop<T> {
                 // Acknowledge resize after event loop.
                 event_state.resize_opt = Some((width, height));
             }
-            //TODO: Clipboard
+            //TODO: Screen, Clipboard, Drop
             EventOption::Hover(HoverEvent { entered }) => {
                 if entered {
                     event_handler(event::Event::WindowEvent {

--- a/src/window.rs
+++ b/src/window.rs
@@ -907,7 +907,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **Web / iOS / Android / Orbital:** Unsupported.
+    /// - **Web / iOS / Android:** Unsupported.
     /// - **X11:** Can only be set while building the window, with [`WindowBuilder::with_transparent`].
     #[inline]
     pub fn set_transparent(&self, transparent: bool) {
@@ -1040,7 +1040,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         self.window
@@ -1051,7 +1051,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn is_maximized(&self) -> bool {
         self.window.maybe_wait_on_main(|w| w.is_maximized())
@@ -1402,7 +1402,7 @@ impl Window {
     /// - **Wayland:** The cursor is only hidden within the confines of the window.
     /// - **macOS:** The cursor is hidden as long as the window has input focus, even if the cursor is
     ///   outside of the window.
-    /// - **iOS / Android / Orbital:** Unsupported.
+    /// - **iOS / Android:** Unsupported.
     #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         self.window
@@ -1419,7 +1419,7 @@ impl Window {
     /// - **X11:** Un-grabs the cursor.
     /// - **Wayland:** Requires the cursor to be inside the window to be dragged.
     /// - **macOS:** May prevent the button release event to be triggered.
-    /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
+    /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
     #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         self.window.maybe_wait_on_main(|w| w.drag_window())
@@ -1433,7 +1433,7 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **macOS:** Always returns an [`ExternalError::NotSupported`]
-    /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
+    /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
     #[inline]
     pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
         self.window
@@ -1587,7 +1587,7 @@ pub enum CursorGrabMode {
     /// ## Platform-specific
     ///
     /// - **macOS:** Not implemented. Always returns [`ExternalError::NotSupported`] for now.
-    /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
+    /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
     Confined,
 
     /// The cursor is locked inside the window area to the certain position.
@@ -1598,7 +1598,7 @@ pub enum CursorGrabMode {
     /// ## Platform-specific
     ///
     /// - **X11 / Windows:** Not implemented. Always returns [`ExternalError::NotSupported`] for now.
-    /// - **iOS / Android / Orbital:** Always returns an [`ExternalError::NotSupported`].
+    /// - **iOS / Android:** Always returns an [`ExternalError::NotSupported`].
     Locked,
 }
 


### PR DESCRIPTION
Implement the following methods on the `Window`:
  - `Window::set_cursor_grab`.
  - `Window::set_cursor_visible`.
  - `Window::drag_window`.
  - `Window::drag_resize_window`.
  - `Window::set_transparent`.
  - `Window::set_visible`.
  - `Window::is_visible`.
  - `Window::set_resizable`.
  - `Window::is_resizable`.
  - `Window::set_maximized`.
  - `Window::is_maximized`.
  - `Window::set_decorations`.
  - `Window::is_decorated`.
  - `Window::set_window_level`.

To make locked pointer useful, the `DeviceEvent::MouseMotion` event was also implemented.

This was merged upstream already.