### PR TITLE
Backported fix for missing Sync in EventLoopProxy in 31f8b816bda59c3d…

### DIFF
--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -493,6 +493,7 @@ pub struct EventLoopProxy<T> {
 }
 
 unsafe impl<T: Send> Send for EventLoopProxy<T> {}
+unsafe impl<T: Send> Sync for EventLoopProxy<T> {}
 
 impl<T> Drop for EventLoopProxy<T> {
     fn drop(&mut self) {


### PR DESCRIPTION
This backports https://github.com/rust-windowing/winit/pull/3449 for macos as required by `DndProvider::init_dnd`.

I only did the macos part because I wanted to minimize the amount of changes. This change is included in winit 0.30, so once upgraded this should no longer be needed.
