### PR TITLE
fix: if the new configure matches, don't overwrite state with None

### DIFF
--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -356,7 +356,7 @@ impl EventLoop {
                 app.window_event(&self.active_event_loop, window_id, event);
             }
 
-            if let Some(new_state) = compositor_update.xdg_window_state {
+            if compositor_update.xdg_window_state.take().is_some() {
                 let window_id = crate::window::WindowId(window_id);
                 let event = WindowEvent::WindowStateChanged;
                 app.window_event(&self.active_event_loop, window_id, event);

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -296,11 +296,9 @@ impl WindowHandler for WinitState {
         self.window_compositor_updates[pos].suggested_bounds |= configure.suggested_bounds
             != winit_window.last_configure.as_ref().and_then(|last| last.suggested_bounds);
 
-        self.window_compositor_updates[pos].xdg_window_state = winit_window
-            .last_configure
-            .as_ref()
-            .is_none_or(|last| last.state != configure.state)
-            .then_some(configure.state);
+        if winit_window.last_configure.as_ref().is_none_or(|last| last.state != configure.state) {
+            self.window_compositor_updates[pos].xdg_window_state = Some(configure.state);
+        }
 
         self.window_compositor_updates[pos].resized |=
             winit_window.configure(configure, &self.shm, &self.subcompositor_state);


### PR DESCRIPTION
Fixes the issues with stack corners