### PR TITLE
fix(platform/orbital): handle `EINTR` when reading from `event_socket`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -157,3 +157,4 @@ changelog entry.
 - On macOS, fix `WindowEvent::Moved` sometimes being triggered unnecessarily on resize.
 - On MacOS, package manifest definitions of `LSUIElement` will no longer be overridden with the
   default activation policy, unless explicitly provided during initialization.
+- On Redox, handle `EINTR` when reading from `event_socket` instead of panicking.

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -648,7 +648,13 @@ impl EventLoop {
 
             // Wait for event if needed.
             let mut event = syscall::Event::default();
-            self.window_target.event_socket.read(&mut event).unwrap();
+            loop {
+                match self.window_target.event_socket.read(&mut event) {
+                    Ok(_) => break,
+                    Err(syscall::Error { errno: syscall::EINTR }) => continue,
+                    Err(err) => unreachable!("failed to read event: {}", err),
+                }
+            }
 
             // TODO: handle spurious wakeups (redraw caused wakeup but redraw already handled)
             match requested_resume {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~ (N/A)
- [x] ~~Created or updated an example program if it would help users understand this functionality~~ (N/A)
- [x] ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~ (N/A)
