### PR TITLE
refactor: Use libredox instead of redox_syscall to open orbital scheme resources.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,8 @@ xkbcommon-dl = "0.4.2"
 # Orbital
 [target.'cfg(target_os = "redox")'.dependencies]
 orbclient = { version = "0.3.47", default-features = false }
-redox_syscall = "0.5"
+redox_syscall = "0.7"
+libredox = "0.1.12"
 
 # Web
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -36,7 +36,7 @@ impl RedoxSocket {
     // example, the seek would change in a potentially unpredictable way if either read or write
     // were called at the same time by multiple threads.
     fn open_raw(path: &str) -> syscall::Result<Self> {
-        let fd = syscall::open(path, syscall::O_RDWR | syscall::O_CLOEXEC)?;
+        let fd = libredox::call::open(path, libredox::flag::O_RDWR | libredox::flag::O_CLOEXEC, 0)?;
         Ok(Self { fd })
     }
 
@@ -154,7 +154,7 @@ struct WindowProperties<'a> {
 
 impl<'a> WindowProperties<'a> {
     fn new(path: &'a str) -> Self {
-        // orbital:flags/x/y/w/h/t
+        // /scheme/orbital/flags/x/y/w/h/t
         let mut parts = path.splitn(6, '/');
         let flags = parts.next().unwrap_or("");
         let x = parts.next().map_or(0, |part| part.parse::<i32>().unwrap_or(0));
@@ -170,7 +170,7 @@ impl<'a> fmt::Display for WindowProperties<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "orbital:{}/{}/{}/{}/{}/{}",
+            "/scheme/orbital/{}/{}/{}/{}/{}/{}",
             self.flags, self.x, self.y, self.w, self.h, self.title
         )
     }


### PR DESCRIPTION
Redox OS will remove `SYS_OPEN`.
Therefore, calling raw `syscall::open` must be replaced with `libredox::open`.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
