### PR TITLE
refactor: Reimplement Orbital suppport using std::fs and redox_event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,7 @@ xkbcommon-dl = "0.4.2"
 # Orbital
 [target.'cfg(target_os = "redox")'.dependencies]
 orbclient = { version = "0.3.47", default-features = false }
-redox_syscall = "0.7"
+redox_event = { package = "redox_event", version = "0.4.3" }
 libredox = "0.1.12"
 
 # Web

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::collections::VecDeque;
+use std::io::{self, Read};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Instant;
 use std::{mem, slice};
@@ -9,11 +10,12 @@ use orbclient::{
     ButtonEvent, EventOption, FocusEvent, HoverEvent, KeyEvent, MouseEvent, MouseRelativeEvent,
     MoveEvent, QuitEvent, ResizeEvent, ScrollEvent, TextInputEvent,
 };
+use redox_event::{EventFlags, EventQueue, UserData};
 use smol_str::SmolStr;
 
 use super::{
-    DeviceId, KeyEventExtra, MonitorHandle, PlatformSpecificEventLoopAttributes, RedoxSocket,
-    TimeSocket, WindowId, WindowProperties,
+    DeviceId, EventSource, KeyEventExtra, MonitorHandle, PlatformSpecificEventLoopAttributes,
+    RedoxSocket, TimeSocket, WindowId, WindowProperties,
 };
 use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, NotSupportedError, RequestError};
@@ -285,17 +287,13 @@ impl EventLoop {
         let (user_events_sender, user_events_receiver) = mpsc::sync_channel(1);
 
         let event_socket =
-            Arc::new(RedoxSocket::event().map_err(|error| os_error!(format!("{error}")))?);
+            Arc::new(EventQueue::new().map_err(|error| os_error!(format!("{error}")))?);
 
         let wake_socket =
             Arc::new(TimeSocket::open().map_err(|error| os_error!(format!("{error}")))?);
 
         event_socket
-            .write(&syscall::Event {
-                id: wake_socket.0.fd,
-                flags: syscall::EventFlags::EVENT_READ,
-                data: wake_socket.0.fd,
-            })
+            .subscribe(wake_socket.0.fd(), EventSource::Time, EventFlags::READ)
             .map_err(|error| os_error!(format!("{error}")))?;
 
         Ok(Self {
@@ -505,7 +503,7 @@ impl EventLoop {
                 let mut creates = self.window_target.creates.lock().unwrap();
                 creates.pop_front()
             } {
-                let window_id = WindowId { fd: window.fd as u64 };
+                let window_id = WindowId { fd: window.fd() as u64 };
 
                 let mut buf: [u8; 4096] = [0; 4096];
                 let path = window.fpath(&mut buf).expect("failed to read properties");
@@ -531,18 +529,18 @@ impl EventLoop {
             } {
                 let window_id = RootWindowId(destroy_id);
                 app.window_event(&self.window_target, window_id, event::WindowEvent::Destroyed);
-                self.windows.retain(|(window, _event_state)| window.fd as u64 != destroy_id.fd);
+                self.windows.retain(|(window, _event_state)| window.fd() as u64 != destroy_id.fd);
             }
 
             // Handle window events.
             let mut i = 0;
             // While loop is used here because the same window may be processed more than once.
             while let Some((window, event_state)) = self.windows.get_mut(i) {
-                let window_id = WindowId { fd: window.fd as u64 };
+                let window_id = WindowId { fd: window.fd() as u64 };
 
                 let mut event_buf = [0u8; 16 * mem::size_of::<orbclient::Event>()];
-                let count =
-                    syscall::read(window.fd, &mut event_buf).expect("failed to read window events");
+                let count = libredox::call::read(window.fd(), &mut event_buf)
+                    .expect("failed to read window events");
                 // Safety: orbclient::Event is a packed struct designed to be transferred over a
                 // socket.
                 let events = unsafe {
@@ -622,11 +620,7 @@ impl EventLoop {
 
             self.window_target
                 .event_socket
-                .write(&syscall::Event {
-                    id: timeout_socket.0.fd,
-                    flags: syscall::EventFlags::EVENT_READ,
-                    data: 0,
-                })
+                .subscribe(timeout_socket.0.fd(), EventSource::Time, EventFlags::READ)
                 .unwrap();
 
             let start = Instant::now();
@@ -635,7 +629,7 @@ impl EventLoop {
 
                 if let Some(duration) = instant.checked_duration_since(start) {
                     time.tv_sec += duration.as_secs() as i64;
-                    time.tv_nsec += duration.subsec_nanos() as i32;
+                    time.tv_nsec += duration.subsec_nanos() as i64;
                     // Normalize timespec so tv_nsec is not greater than one second.
                     while time.tv_nsec >= 1_000_000_000 {
                         time.tv_sec += 1;
@@ -647,18 +641,20 @@ impl EventLoop {
             }
 
             // Wait for event if needed.
-            let mut event = syscall::Event::default();
-            loop {
-                match self.window_target.event_socket.read(&mut event) {
-                    Ok(_) => break,
-                    Err(syscall::Error { errno: syscall::EINTR }) => continue,
+            let event = loop {
+                match self.window_target.event_socket.next_event() {
+                    Ok(event) => break event,
+                    Err(err) if err.is_interrupt() => continue,
                     Err(err) => unreachable!("failed to read event: {}", err),
                 }
-            }
+            };
 
             // TODO: handle spurious wakeups (redraw caused wakeup but redraw already handled)
             match requested_resume {
-                Some(requested_resume) if event.id == timeout_socket.0.fd => {
+                Some(requested_resume)
+                    if event.fd == timeout_socket.0.fd()
+                        && matches!(event.user_data, EventSource::Time) =>
+                {
                     // If the event is from the special timeout socket, report that resume
                     // time was reached.
                     start_cause = StartCause::ResumeTimeReached { start, requested_resume };
@@ -712,7 +708,7 @@ pub struct ActiveEventLoop {
     pub(super) creates: Mutex<VecDeque<Arc<RedoxSocket>>>,
     pub(super) redraws: Arc<Mutex<VecDeque<WindowId>>>,
     pub(super) destroys: Arc<Mutex<VecDeque<WindowId>>>,
-    pub(super) event_socket: Arc<RedoxSocket>,
+    pub(super) event_socket: Arc<EventQueue<EventSource>>,
     pub(super) wake_socket: Arc<TimeSocket>,
     user_events_sender: mpsc::SyncSender<()>,
 }

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -1,8 +1,13 @@
 #![cfg(target_os = "redox")]
 
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Result, Write};
 use std::num::{NonZeroU16, NonZeroU32};
-use std::{fmt, str};
+use std::os::fd::AsRawFd;
+use std::{fmt, mem, slice, str};
 
+use libredox::data::TimeSpec;
+use redox_event::{user_data, EventFlags};
 use smol_str::SmolStr;
 
 pub(crate) use self::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy, OwnedDisplayHandle};
@@ -18,16 +23,19 @@ pub(crate) use crate::cursor::{
 };
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
+redox_event::user_data! {
+    pub enum EventSource {
+        Orbital,
+        Time,
+    }
+}
+
 struct RedoxSocket {
-    fd: usize,
+    fd: File,
 }
 
 impl RedoxSocket {
-    fn event() -> syscall::Result<Self> {
-        Self::open_raw("event:")
-    }
-
-    fn orbital(properties: &WindowProperties<'_>) -> syscall::Result<Self> {
+    fn orbital(properties: &WindowProperties<'_>) -> Result<Self> {
         Self::open_raw(&format!("{properties}"))
     }
 
@@ -35,64 +43,63 @@ impl RedoxSocket {
     // non-socket path is used, it could cause read and write to not function as expected. For
     // example, the seek would change in a potentially unpredictable way if either read or write
     // were called at the same time by multiple threads.
-    fn open_raw(path: &str) -> syscall::Result<Self> {
-        let fd = libredox::call::open(path, libredox::flag::O_RDWR | libredox::flag::O_CLOEXEC, 0)?;
+    fn open_raw(path: &str) -> Result<Self> {
+        let fd = OpenOptions::new().read(true).write(true).open(path)?;
         Ok(Self { fd })
     }
 
-    fn read(&self, buf: &mut [u8]) -> syscall::Result<()> {
-        let count = syscall::read(self.fd, buf)?;
-        if count == buf.len() {
-            Ok(())
-        } else {
-            Err(syscall::Error::new(syscall::EINVAL))
-        }
+    fn fd(&self) -> usize {
+        self.fd.as_raw_fd() as usize
     }
 
-    fn write(&self, buf: &[u8]) -> syscall::Result<()> {
-        let count = syscall::write(self.fd, buf)?;
-        if count == buf.len() {
-            Ok(())
-        } else {
-            Err(syscall::Error::new(syscall::EINVAL))
-        }
+    fn read(&self, buf: &mut [u8]) -> Result<()> {
+        (&self.fd).read_exact(buf)
     }
 
-    fn fpath<'a>(&self, buf: &'a mut [u8]) -> syscall::Result<&'a str> {
-        let count = syscall::fpath(self.fd, buf)?;
-        str::from_utf8(&buf[..count]).map_err(|_err| syscall::Error::new(syscall::EINVAL))
+    fn write(&self, buf: &[u8]) -> Result<()> {
+        (&self.fd).write_all(buf)
     }
-}
 
-impl Drop for RedoxSocket {
-    fn drop(&mut self) {
-        let _ = syscall::close(self.fd);
+    fn fpath<'a>(&self, buf: &'a mut [u8]) -> Result<&'a str> {
+        let count = libredox::call::fpath(self.fd(), buf)?;
+        str::from_utf8(&buf[..count])
+            .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidData))
     }
 }
 
 pub struct TimeSocket(RedoxSocket);
 
 impl TimeSocket {
-    fn open() -> syscall::Result<Self> {
-        RedoxSocket::open_raw("time:4").map(Self)
+    fn open() -> Result<Self> {
+        RedoxSocket::open_raw("/scheme/time/4").map(Self)
     }
 
     // Read current time.
-    fn current_time(&self) -> syscall::Result<syscall::TimeSpec> {
-        let mut timespec = syscall::TimeSpec::default();
-        self.0.read(&mut timespec)?;
+    fn current_time(&self) -> Result<TimeSpec> {
+        let mut timespec: libredox::data::TimeSpec = unsafe { mem::zeroed() };
+        let timespec_bytes = unsafe {
+            slice::from_raw_parts_mut(
+                &mut timespec as *mut _ as *mut u8,
+                mem::size_of::<TimeSpec>(),
+            )
+        };
+        self.0.read(timespec_bytes)?;
         Ok(timespec)
     }
 
     // Write a timeout.
-    fn timeout(&self, timespec: &syscall::TimeSpec) -> syscall::Result<()> {
-        self.0.write(timespec)
+    fn timeout(&self, timespec: &TimeSpec) -> Result<()> {
+        let timespec_bytes = unsafe {
+            slice::from_raw_parts(timespec as *const _ as *const u8, mem::size_of::<TimeSpec>())
+        };
+        self.0.write(timespec_bytes)
     }
 
     // Wake immediately.
-    fn wake(&self) -> syscall::Result<()> {
+    fn wake(&self) -> Result<()> {
         // Writing a default TimeSpec will always trigger a time event.
-        self.timeout(&syscall::TimeSpec::default())
+        let timespec: TimeSpec = unsafe { mem::zeroed() };
+        self.timeout(&timespec)
     }
 }
 

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -1,7 +1,12 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-use super::{ActiveEventLoop, MonitorHandle, RedoxSocket, TimeSocket, WindowId, WindowProperties};
+use redox_event::{EventFlags, UserData};
+
+use super::{
+    ActiveEventLoop, EventSource, MonitorHandle, RedoxSocket, TimeSocket, WindowId,
+    WindowProperties,
+};
 use crate::cursor::Cursor;
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{NotSupportedError, RequestError};
@@ -99,13 +104,7 @@ impl Window {
         .expect("failed to open window");
 
         // Add to event socket.
-        el.event_socket
-            .write(&syscall::Event {
-                id: window.fd,
-                flags: syscall::EventFlags::EVENT_READ,
-                data: window.fd,
-            })
-            .unwrap();
+        el.event_socket.subscribe(window.fd(), EventSource::Orbital, EventFlags::READ).unwrap();
 
         let window_socket = Arc::new(window);
 
@@ -143,7 +142,7 @@ impl Window {
     #[inline]
     fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         let handle = rwh_06::OrbitalWindowHandle::new({
-            let window = self.window_socket.fd as *mut _;
+            let window = self.window_socket.fd() as *mut _;
             std::ptr::NonNull::new(window).expect("orbital fd should never be null")
         });
         Ok(rwh_06::RawWindowHandle::Orbital(handle))
@@ -158,7 +157,7 @@ impl Window {
 
 impl CoreWindow for Window {
     fn id(&self) -> CoreWindowId {
-        CoreWindowId(WindowId { fd: self.window_socket.fd as u64 })
+        CoreWindowId(WindowId { fd: self.window_socket.fd() as u64 })
     }
 
     #[inline]


### PR DESCRIPTION
The RedoxSocket implementation using libredox can simply use `std::fs` instead.
Also, `event_socket` should be implemented using redox_event.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
